### PR TITLE
Reducers actions implemented and correction to reducers test

### DIFF
--- a/reducers/organisations.js
+++ b/reducers/organisations.js
@@ -1,0 +1,60 @@
+'use strict';
+
+const initialState = [
+    {
+        name: 'JavaScript 101',
+        selected: false,
+        id: 1
+    }
+];
+
+export default function organisations (state = initialState, action) {
+
+    switch (action.type) {
+        case 'SELECT_ORGANISATION':
+            return Object.assign(state,
+                state.reduce((arr, org) => {
+                    if (org.id === action.id) {
+                       org.selected = true;
+                       return org;
+                    }
+                },[])
+            );
+
+        case 'DESELECT_ORGANISATION':
+            return Object.assign(state,
+                state.reduce((arr, org) => {
+                    if (org.id === action.id) {
+                        org.selected = false;
+                        return org;
+                    }
+                },[])
+            );
+
+        case 'ADD_ORGANISATION':
+            state.push({
+                name: action.name,
+                selected: false,
+                id: state.length + 1
+            });
+            return state;
+
+        case 'EDIT_ORGANISATION':
+            return Object.assign(state,
+                state.reduce((arr, org) => {
+                    if (org.id === action.id) {
+                        org.name = action.name;
+                        return org;
+                    }
+                },[])
+            );
+
+        case 'DELETE_ORGANISATION':
+            return state.filter(org => {
+            if (org.id !== action.id) return true
+            })
+
+        default:
+            return state;
+    }
+}

--- a/test/reducers/organisations.spec.js
+++ b/test/reducers/organisations.spec.js
@@ -3,7 +3,7 @@ import organisations from '../../reducers/organisations'
 import * as types from '../../constants/ActionTypes'
 
 describe('organisations reducer', () => {
-  it('shouild handle inital state', () => {
+  it('should handle inital state', () => {
     expect(
       organisations(undefined, {})
     ).toEqual([
@@ -15,7 +15,7 @@ describe('organisations reducer', () => {
     ])
   })
 
-  it('shouild handle SELECT_ORGANISATION', () => {
+  it('should handle SELECT_ORGANISATION', () => {
     expect(
       organisations([
         {
@@ -36,7 +36,7 @@ describe('organisations reducer', () => {
     ])
   })
 
-  it('shouild handle DESELECT_ORGANISATION', () => {
+  it('should handle DESELECT_ORGANISATION', () => {
     expect(
       organisations([
         {
@@ -57,11 +57,11 @@ describe('organisations reducer', () => {
     ])
   })
 
-  it('shouild handle ADD_ORGANISATION', () => {
+  it('should handle ADD_ORGANISATION', () => {
     expect(
       organisations([],  {
           type: types.ADD_ORGANISATION,
-          name: 'CodeHub Bristol'
+          name: 'Javascript 101'
         })
     ).toEqual([
       {
@@ -130,7 +130,7 @@ describe('organisations reducer', () => {
     ])
   })
 
-  it('shouild handle EDIT_ORGANISATION', () => {
+  it('should handle EDIT_ORGANISATION', () => {
     expect(
       organisations([
         {
@@ -162,7 +162,7 @@ describe('organisations reducer', () => {
     ])
   })
 
-  it('shouild handle EDIT_ORGANISATION', () => {
+  it('should handle EDIT_ORGANISATION', () => {
     expect(
       organisations([
         {
@@ -194,7 +194,7 @@ describe('organisations reducer', () => {
     ])
   })
 
-  it('shouild handle DELETE_ORGANISATION', () => {
+  it('should handle DELETE_ORGANISATION', () => {
     expect(
       organisations([
         {

--- a/test/reducers/organisations.spec.js
+++ b/test/reducers/organisations.spec.js
@@ -61,7 +61,7 @@ describe('organisations reducer', () => {
     expect(
       organisations([],  {
           type: types.ADD_ORGANISATION,
-          name: 'Javascript 101'
+          name: 'JavaScript 101'
         })
     ).toEqual([
       {


### PR DESCRIPTION
I have implemented the five reducer actions. All pass.

I had to alter one of the tests. The first test on ADD_ORGANISATION expected {name: "CodeHub Bristol"} to equal {name: "Javascript 101"}. For this action, the name value should remain the unchanged. (My apologies if I've assumed wrong!)

I also corrected a few typos. 'Should' was written as 'shouild' in the test descriptions. 

The test still has two fails:
- 1) Organisation List component should display a bootstrap table…
-  2) Organisation List component should display table headers…
